### PR TITLE
Propagate serde_yaml::Error

### DIFF
--- a/component/cargo/Cargo.lock
+++ b/component/cargo/Cargo.lock
@@ -666,6 +666,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "xr-parse-macro"
+version = "0.0.1"
+dependencies = [
+ "xr-parse",
+]
+
+[[package]]
 name = "xr-token"
 version = "0.0.1"
 

--- a/component/cargo/Cargo.toml
+++ b/component/cargo/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     './xr',
     './xr-dyn',
     './xr-parse',
+    './xr-parse-macro',
     './xr-token',
     './xs',
 ]
@@ -18,6 +19,9 @@ path = './xr-dyn'
 
 [patch.crates-io.xr-parse]
 path = './xr-parse'
+
+[patch.crates-io.xr-parse-macro]
+path = './xr-parse-macro'
 
 [patch.crates-io.xr-token]
 path = './xr-token'

--- a/component/cargo/Cargo.yaml
+++ b/component/cargo/Cargo.yaml
@@ -12,6 +12,7 @@ module:
       - ron
       - serde
       - serde_json
+      - serde_yaml
       - termcolor
       - wind
       - xerr

--- a/component/cargo/xs/src/cli.rs
+++ b/component/cargo/xs/src/cli.rs
@@ -33,11 +33,8 @@ where
                 let env_file_path =
                     te!(env_file_path, "Missing argument to --env-file")
                         .as_ref();
-                let env_file = std::fs::File::open(env_file_path)?;
-                match serde_yaml::from_reader::<_, EnvFile>(&env_file) {
-                    Ok(envs) => opts.envs = envs,
-                    Err(err) => println!("{:?}", err),
-                }
+                let env_file = fs::File::open(env_file_path)?;
+                opts.envs = te!(serde_yaml::from_reader::<_, EnvFile>(&env_file), "Error loading yaml");
             }
             Some("--env-context") => {
                 let env_context = i.next();

--- a/component/cargo/xs/src/error.rs
+++ b/component/cargo/xs/src/error.rs
@@ -5,6 +5,7 @@ xError! {
     Utf8 = std::str::Utf8Error
     Utf8_ = std::string::FromUtf8Error
     Json = json::Error
+    Yaml = yaml::Error
     Xc = xc::Error
     Var = std::env::VarError
 }

--- a/component/cargo/xs/src/main.rs
+++ b/component/cargo/xs/src/main.rs
@@ -88,6 +88,7 @@ use {
     error::{err, te, xerr, Error, Result},
     input::Input,
     serde_json as json,
+    serde_yaml as yaml,
     std::{
         borrow::{Borrow, BorrowMut, Cow},
         collections::{


### PR DESCRIPTION
Adds `serde_yaml::Error` to the error union, which allows `parse_args` to propagate (throw) it normally.